### PR TITLE
Getting CICD Online

### DIFF
--- a/BLUI.uplugin
+++ b/BLUI.uplugin
@@ -8,7 +8,7 @@
 	"CreatedBy": "Aaron M. Shea, Getnamo, & Contributors",
 	"CreatedByURL": "github.com/aaronShea",
 	"DocsURL": "https://github.com/getnamo/BLUI",
-	"EnabledByDefault" : true,
+	"EnabledByDefault" : false,
 	"CanContainContent": "true",
 	"Modules": 
 	[

--- a/Source/Blu/Private/Blu.cpp
+++ b/Source/Blu/Private/Blu.cpp
@@ -8,6 +8,10 @@ class FBlu : public IBlu
 	/** IModuleInterface implementation */
 	virtual void StartupModule() override
 	{
+#if ENGINE_MAJOR_VERSION >= 5
+		return;
+#endif
+
 		CefString GameDirCef = *FPaths::ConvertRelativePathToFull(FPaths::ProjectDir() + "BluCache");
 		FString ExecutablePath = FPaths::ConvertRelativePathToFull(IPluginManager::Get().FindPlugin(TEXT("BLUI"))->GetBaseDir() + "/ThirdParty/cef/");
 		CefString CefLogPath = *FPaths::ConvertRelativePathToFull(FPaths::ProjectDir() + "Saved/Logs/blui_cef.log");

--- a/Source/Blu/Private/BluEye.cpp
+++ b/Source/Blu/Private/BluEye.cpp
@@ -32,7 +32,7 @@ bool UBluEye::Init()
 	 * If we don't check this, CEF will spawn infinite processes with widget components
 	 **/
 
-	if (GEngine)
+	if (GEngine && !GUsingNullRHI)
 	{
 		if (GEngine->IsEditor() && !GWorld->IsPlayInEditor())
 		{
@@ -201,6 +201,8 @@ void UBluEye::TextureUpdate(const void *buffer, FUpdateTextureRegion2D *updateRe
 		RegionData->SrcData.SetNumUninitialized(RegionData->SrcPitch * Settings.Height);
 		FPlatformMemory::Memcpy(RegionData->SrcData.GetData(), buffer, RegionData->SrcData.Num());
 
+		if (RegionData->Texture2DResource)
+		{
 		ENQUEUE_RENDER_COMMAND(UpdateBLUICommand)(
 			[RegionData](FRHICommandList& CommandList)
 			{
@@ -214,6 +216,7 @@ void UBluEye::TextureUpdate(const void *buffer, FUpdateTextureRegion2D *updateRe
 				FMemory::Free(RegionData->Regions);
 				delete RegionData;
 			});
+		}
 
 	}
 	else {

--- a/Source/Blu/Public/BluTypes.h
+++ b/Source/Blu/Public/BluTypes.h
@@ -1,17 +1,21 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Containers/Ticker.h"
 #include "BluTypes.generated.h"
 
 struct FTickEventLoopData
 {
+#if ENGINE_MAJOR_VERSION < 5
 	FDelegateHandle DelegateHandle;
+#else
+	FTSTicker::FDelegateHandle DelegateHandle;
+#endif
 	int32 EyeCount;
 	bool bShouldTickEventLoop;
 
 	FTickEventLoopData()
 	{
-		DelegateHandle = FDelegateHandle();
 		EyeCount = 0;
 		bShouldTickEventLoop = true;
 	}


### PR DESCRIPTION
# Summary
Miscellaneous work to bring CI/CD online.

# Customer Impact
BLUI is disabled by default. This is required as we are transitioning to automate switching between BLUI and WBW

## Fixed
Compile issues on 5.2, 5.3, 5.4


- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs: `, `refactor: ` or `test: `.
- [ ] Sample blueprints are updated with new SDK changes
- [ ] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unreal) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unreal))
- [ ] Replied to GitHub issues
