### PR TITLE
Fix Typos in `cef_devtools_message_observer.h` and `cef_life_span_handler.h`

### DIFF
--- a/ThirdParty/cef/Win/include/cef_devtools_message_observer.h
+++ b/ThirdParty/cef/Win/include/cef_devtools_message_observer.h
@@ -59,7 +59,7 @@ class CefDevToolsMessageObserver : public virtual CefBaseRefCounted {
   // OnDevToolsEvent methods as appropriate.
   //
   // Method result dictionaries include an "id" (int) value that identifies the
-  // orginating method call sent from CefBrowserHost::SendDevToolsMessage, and
+  // originating method call sent from CefBrowserHost::SendDevToolsMessage, and
   // optionally either a "result" (dictionary) or "error" (dictionary) value.
   // The "error" dictionary will contain "code" (int) and "message" (string)
   // values. Event dictionaries include a "method" (string) value and optionally

--- a/ThirdParty/cef/Win/include/cef_life_span_handler.h
+++ b/ThirdParty/cef/Win/include/cef_life_span_handler.h
@@ -102,7 +102,7 @@ class CefLifeSpanHandler : public virtual CefBaseRefCounted {
   virtual void OnAfterCreated(CefRefPtr<CefBrowser> browser) {}
 
   ///
-  // Called when a browser has recieved a request to close. This may result
+  // Called when a browser has received a request to close. This may result
   // directly from a call to CefBrowserHost::*CloseBrowser() or indirectly if
   // the browser is parented to a top-level window created by CEF and the user
   // attempts to close that window (by clicking the 'X', for example). The


### PR DESCRIPTION
## Pull Request: Fix Typos in `cef_devtools_message_observer.h` and `cef_life_span_handler.h`

### Description  
This PR fixes minor typos in the following files:  
1. **`cef_devtools_message_observer.h`**  
2. **`cef_life_span_handler.h`**

---

### Changes  

#### File: `cef_devtools_message_observer.h`  
- **Line 59**  
   **Before:**  
   > *"orginating method call sent from CefBrowserHost::SendDevToolsMessage"*  
   **After:**  
   > *"originating method call sent from CefBrowserHost::SendDevToolsMessage"*  

#### File: `cef_life_span_handler.h`  
- **Line 102**  
   **Before:**  
   > *"when a browser has **recieved** a request to close."*  
   **After:**  
   > *"when a browser has **received** a request to close."*  

---

### Summary of Changes  
- **2 files modified**:  
   - Fixed 2 spelling errors:  
     - "orginating" → "originating"  
     - "recieved" → "received"  

---

### Author  
**@teenager-ETH**

---

### Review  
Please review and confirm the corrections. Let me know if further adjustments are needed.  
